### PR TITLE
Rename loader to goloader to avoid name collision

### DIFF
--- a/goloader/loader.go
+++ b/goloader/loader.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package loader
+package goloader
 
 import (
 	"encoding/binary"


### PR DESCRIPTION
This change should be merged along with the arb-validator changes